### PR TITLE
For getting delet option order at the bottom

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
       },
       {
         "command": "ftpkr.delete",
-        "title": "Delete This",
+        "title": "WARNING: Delete This",
         "category": "ftp-kr"
       },
       {


### PR DESCRIPTION
As menu options are ordered in alphabetical order, adding a string with later alphabets like in this commit with getting the delete option ordered at the bottom making it safe and secure to avoid any conflict between `Download This` and `Delete This` which is happening for many of us in present.

**REF**: [ ISSUE#81](https://github.com/karikera/ftp-kr/issues/81
) 